### PR TITLE
Fjerne bruk av 310 interval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,6 @@
 				<artifactId>jackson-datatype-jsr310</artifactId>
 				<version>[2.9.3,2.10.5)</version>
 			</dependency>
-			<dependency>
-				<groupId>org.threeten</groupId>
-				<artifactId>threeten-extra</artifactId>
-				<version>[1.5,1.10)</version>
-				<scope>provided</scope>
-			</dependency>
 
 		</dependencies>
 	</dependencyManagement>
@@ -82,11 +76,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.threeten</groupId>
-			<artifactId>threeten-extra</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/no/nav/fpsak/tidsserie/LocalDateInterval.java
+++ b/src/main/java/no/nav/fpsak/tidsserie/LocalDateInterval.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.Period;
-import java.time.ZoneId;
 import java.time.chrono.ChronoLocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -13,8 +12,6 @@ import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeSet;
-
-import org.threeten.extra.Interval;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -81,14 +78,6 @@ public class LocalDateInterval implements Comparable<LocalDateInterval>, Seriali
 
     public static LocalDate min(LocalDate en, LocalDate to) {
         return en.isBefore(to) ? en : to;
-    }
-
-    public static Interval toInterval(LocalDate startDateInclusive, LocalDate endDate, boolean includeEnd) {
-        var end = TIDENES_ENDE.equals(endDate) ? endDate.atStartOfDay()
-                : includeEnd ? endDate.atStartOfDay().plusDays(1) : endDate.atStartOfDay();
-        return Interval.of(
-                startDateInclusive.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant(),
-                end.atZone(ZoneId.systemDefault()).toInstant());
     }
 
     public static LocalDateInterval withPeriodAfterDate(LocalDate startDate, Period period) {
@@ -269,10 +258,6 @@ public class LocalDateInterval implements Comparable<LocalDateInterval>, Seriali
         resultat.addAll(this.except(annen));
         this.overlap(annen).ifPresent(o -> resultat.add(o));
         return resultat;
-    }
-
-    public Interval toInterval() {
-        return toInterval(getFomDato(), getTomDato(), true);
     }
 
     public Period toPeriod() {


### PR DESCRIPTION
Vi kan kanskje øke limit'en på jackson-versjoner fra 2.10.5 til 2.13 eller ha den åpen ?
Siste jackson er 2.12.2 fra tidlig mars 2021 - de fleste apps har 2.12.1