### PR TITLE
JUnit er jo eit testbibliotek, så scoper importen av det til å kun gjelde testkode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Nyttig både her og for dei som bruker dette biblioteket å sikre at ikkje testbibliotek lekk inn i prodkoden